### PR TITLE
Allow admins to enter custom discounts

### DIFF
--- a/backend/routes/discounts.js
+++ b/backend/routes/discounts.js
@@ -28,10 +28,23 @@ router.get('/:restaurant_id', async (req, res) => {
 
     const { expected_customers, discounts, accepted_discounts } = result[0];
 
+    // Older documents may store booleans. Convert `true` to the predicted
+    // discount value so the frontend can prefill the amount field.
+    const convertedAccepted = {};
+    if (accepted_discounts) {
+      for (const [hour, value] of Object.entries(accepted_discounts)) {
+        if (value === true) {
+          convertedAccepted[hour] = discounts[hour];
+        } else {
+          convertedAccepted[hour] = value;
+        }
+      }
+    }
+
     res.status(200).json({
       expected_customers,
       discounts,
-      accepted_discounts,
+      accepted_discounts: convertedAccepted,
     });
   } catch (error) {
     console.error('❌ Error fetching discounts:', error);
@@ -67,13 +80,19 @@ router.post('/respond', async (req, res) => {
     }
 
     // Step 2: Build full accepted_discounts object
+    // Instead of booleans, store the discount value when accepted
+    // and false when rejected
     const fullAccepted = {};
     const allHours = Object.keys(latest.discounts);
 
     for (const hour of allHours) {
-      fullAccepted[hour] = accepted_discounts.hasOwnProperty(hour)
-        ? accepted_discounts[hour]
-        : false;  // Default to false (rejected) if not explicitly included
+      if (accepted_discounts.hasOwnProperty(hour)) {
+        const val = accepted_discounts[hour];
+        // Accept numbers only; anything else counts as rejection
+        fullAccepted[hour] = typeof val === 'number' ? val : false;
+      } else {
+        fullAccepted[hour] = false;  // Default to rejected
+      }
     }
 
     // Step 3: Update the document

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -28,9 +28,9 @@ router.get('/active-discounts', async (req, res) => {
       if (!latest || !latest.accepted_discounts) continue;
 
       const active = {};
-      for (const [hour, accepted] of Object.entries(latest.accepted_discounts)) {
-        if (accepted) {
-          active[hour] = latest.discounts[hour];
+      for (const [hour, value] of Object.entries(latest.accepted_discounts)) {
+        if (typeof value === 'number') {
+          active[hour] = value;
         }
       }
 

--- a/frontend/admin/src/components/DiscountManager.jsx
+++ b/frontend/admin/src/components/DiscountManager.jsx
@@ -18,9 +18,19 @@ function DiscountManager({restaurantId}) {
 
 
     const toggle = (hour) => {
+        setAccepted(prev => {
+            const current = prev[hour];
+            if (typeof current === 'number') {
+                return {...prev, [hour]: false};
+            }
+            return {...prev, [hour]: data.discounts[hour]};
+        });
+    };
+
+    const updateValue = (hour, value) => {
         setAccepted(prev => ({
             ...prev,
-            [hour]: !prev[hour]
+            [hour]: value
         }));
     };
 
@@ -46,7 +56,8 @@ function DiscountManager({restaurantId}) {
                     <thead>
                     <tr className="bg-gray-100">
                         <th className="p-2 border-b text-sm font-medium">Hour</th>
-                        <th className="p-2 border-b text-sm font-medium">Discount</th>
+                        <th className="p-2 border-b text-sm font-medium">Predicted</th>
+                        <th className="p-2 border-b text-sm font-medium">Custom Discount</th>
                         <th className="p-2 border-b text-sm font-medium">Accept</th>
                     </tr>
                     </thead>
@@ -56,12 +67,22 @@ function DiscountManager({restaurantId}) {
                             <td className="p-2 border-b text-sm">{hour}:00</td>
                             <td className="p-2 border-b text-sm">{data.discounts[hour]}%</td>
                             <td className="p-2 border-b text-sm">
+                                <input
+                                    type="number"
+                                    min="0"
+                                    className="border rounded p-1 w-20"
+                                    disabled={typeof accepted[hour] !== 'number'}
+                                    value={typeof accepted[hour] === 'number' ? accepted[hour] : ''}
+                                    onChange={(e) => updateValue(hour, Number(e.target.value))}
+                                />
+                            </td>
+                            <td className="p-2 border-b text-sm">
                                 <label
                                     className="relative inline-block w-12 h-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer">
 
                                     <input
                                         type="checkbox"
-                                        checked={!!accepted[hour]}
+                                        checked={typeof accepted[hour] === 'number'}
                                         onChange={() => toggle(hour)}
                                         className="opacity-0 w-0 h-0 peer"
                                     />
@@ -71,7 +92,6 @@ function DiscountManager({restaurantId}) {
                                         className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full shadow transition-transform duration-300 peer-checked:translate-x-6"></span>
                                 </label>
                             </td>
-
                         </tr>
                     ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- support numeric discount values in backend API
- surface custom discount editing in admin UI

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `frontend/admin` *(fails: Missing script)*
- `npm test` in `frontend/user` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849723859ac832f80a0f702b30ae705