### PR TITLE
Improve dashboard styling

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Admin Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/admin/src/App.jsx
+++ b/frontend/admin/src/App.jsx
@@ -27,10 +27,12 @@ function App() {
   }, [restaurantId]);
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <h1 className="text-3xl text-center font-bold text-blue-700 mb-4">Admin Dashboard</h1>
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-100 py-8">
+      <header className="mb-8">
+        <h1 className="text-4xl text-center font-extrabold text-blue-800">Admin Dashboard</h1>
+      </header>
 
-      <div className="max-w-md mx-auto text-center mb-6">
+      <div className="max-w-md mx-auto mb-8 bg-white p-4 rounded shadow">
         <label className="block mb-2 font-medium text-gray-700">Select Restaurant</label>
         <select
           value={restaurantId}

--- a/frontend/admin/src/components/DiscountManager.jsx
+++ b/frontend/admin/src/components/DiscountManager.jsx
@@ -52,7 +52,7 @@ function DiscountManager({restaurantId}) {
             </h2>
 
             <div className="overflow-x-auto">
-                <table className="w-full text-left border-collapse">
+                <table className="w-full text-left border-collapse divide-y divide-gray-200">
                     <thead>
                     <tr className="bg-gray-100">
                         <th className="p-2 border-b text-sm font-medium">Hour</th>
@@ -63,7 +63,7 @@ function DiscountManager({restaurantId}) {
                     </thead>
                     <tbody>
                     {Object.keys(data.discounts).sort((a, b) => Number(a) - Number(b)).map(hour => (
-                        <tr key={hour} className="hover:bg-gray-50">
+                        <tr key={hour} className="hover:bg-gray-50 odd:bg-white even:bg-gray-50">
                             <td className="p-2 border-b text-sm">{hour}:00</td>
                             <td className="p-2 border-b text-sm">{data.discounts[hour]}%</td>
                             <td className="p-2 border-b text-sm">
@@ -101,7 +101,7 @@ function DiscountManager({restaurantId}) {
             <div className="text-center mt-6">
                 <button
                     onClick={submit}
-                    className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded shadow"
+                    className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold py-2 px-6 rounded shadow"
                 >
                     Submit Accepted Discounts
                 </button>

--- a/frontend/user/index.html
+++ b/frontend/user/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Customer Deals Portal</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/user/src/App.jsx
+++ b/frontend/user/src/App.jsx
@@ -1,12 +1,15 @@
 import DiscountBrowser from './components/DiscountBrowser';
 
 function App() {
-    return (
-        <div className="min-h-screen bg-gray-50 py-8">
-            <h1 className="text-3xl text-center font-bold text-blue-700 mb-4">Customer Deals Portal</h1>
-            <DiscountBrowser/>
-        </div>
-    );
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-100 py-8">
+      <header className="mb-8">
+        <h1 className="text-4xl text-center font-extrabold text-blue-800">Customer Deals Portal</h1>
+        <p className="text-center text-gray-600">Find today\'s best restaurant discounts</p>
+      </header>
+      <DiscountBrowser />
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/user/src/components/DiscountBrowser.jsx
+++ b/frontend/user/src/components/DiscountBrowser.jsx
@@ -25,30 +25,31 @@ function DiscountBrowser() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto mt-10 px-4">
+    <div className="max-w-5xl mx-auto mt-10 px-4">
       <h2 className="text-2xl font-bold text-center mb-6">Today’s Restaurant Discounts</h2>
-      <div className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2">
         {data.map((restaurant) => (
           <div
             key={restaurant.restaurant_id}
-            className="bg-white shadow-md rounded-lg p-4 border border-gray-200"
+            className="bg-white shadow-lg rounded-lg border border-gray-200 overflow-hidden"
           >
-            <h3 className="text-xl font-semibold text-gray-800 mb-2">
-              {restaurant.restaurant_name}
-            </h3>
-            <p className="text-sm text-gray-500 mb-3">Restaurant ID: {restaurant.restaurant_id}</p>
-
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(restaurant.active_discounts)
-                .sort(([a], [b]) => Number(a) - Number(b))
-                .map(([hour, discount]) => (
-                  <div
-                    key={hour}
-                    className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium shadow-sm"
-                  >
-                    {hour}:00 → {discount}%
-                  </div>
-                ))}
+            <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-4 py-2">
+              <h3 className="text-lg font-semibold">{restaurant.restaurant_name}</h3>
+            </div>
+            <div className="p-4">
+              <p className="text-sm text-gray-500 mb-3">Restaurant ID: {restaurant.restaurant_id}</p>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(restaurant.active_discounts)
+                  .sort(([a], [b]) => Number(a) - Number(b))
+                  .map(([hour, discount]) => (
+                    <div
+                      key={hour}
+                      className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium shadow-sm"
+                    >
+                      {hour}:00 → {discount}%
+                    </div>
+                  ))}
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- style pages with gradient backgrounds, headers, and cards
- update index titles for admin and customer portals

## Testing
- `npm --prefix frontend/user run lint` *(fails: Cannot find package)*
- `npm --prefix frontend/admin run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6849755dc9dc832fae7df5a40deeb443